### PR TITLE
Make keyword checks case insensitive

### DIFF
--- a/ChatScanner.lua
+++ b/ChatScanner.lua
@@ -79,7 +79,7 @@ local function HasMatch(message, tokens, secondary_keywords)
     local len = nil;
     local numMatches = 0;
     for _, token in pairs(tokens) do
-        local b, e = string.find(message, token)
+        local b, e = string.find(message:lower(), token:lower())
         if HasMatchCheck(b, e, message) then
             if not len or len < #token then
                 len = #token;


### PR DESCRIPTION
Hi! 

Huge fan of the addon :)
I did notice that I have to manually create each of the variations of a keyword if I want to make sure I don't miss a message

For example, if I have chat detection set to look for "recraft, Recraft" but then someone sends a message which has RECRAFT instead of the other 2 cases I covered then it will not be detected.
I think all 3 variations are perfectly valid to be returned as a match; and I'd prefer to copy every word multiple times 🥲 

This PR will convert the message and the tokens to lowercase at the time of comparison.

I have not tested this with non-latin characters but I assume it to work well with them.
Let me know if you see any issues with this PR and I'll try my best to change it!

Keep up the good work 👍 