### PR TITLE
Fix nil reference error in PopulateProfessionNode

### DIFF
--- a/Config/ConfigPage.lua
+++ b/Config/ConfigPage.lua
@@ -323,6 +323,13 @@ local function MakeProfessionNodeFactory(root)
         -- for the user to see instead of freezing the screen.
         local perFrame = existingRecipeIDs and 5 or 10000000
 
+        if not profConfig.recipes then
+            if onFinished then
+                onFinished()
+            end
+            return
+        end
+
         CraftScan.TimeSlice(profConfig.recipes, perFrame, function(recipeID, recipeConfig)
             if not existingRecipeIDs or not existingRecipeIDs[recipeID] then
                 local parentNode = GetRecipeParentNode(char, profID, profConfig, recipeConfig)


### PR DESCRIPTION
Fixes a crash when opening the config page where profConfig.recipes is nil.

The error occurred when the code iterated through character professions and attempted to call TimeSlice with a nil recipes table. This change adds a guard clause to check if profConfig.recipes exists before processing, and calls the onFinished callback to maintain proper execution flow.

Error fixed: TimeSlice.lua:59: bad argument #1 to 'pairs' (table expected, got nil)

Fixes #88