### PR TITLE
Fix taint-related arithmetic errors in MoneyFrame (#96)

### DIFF
--- a/Config/RecipeConfigPanel.lua
+++ b/Config/RecipeConfigPanel.lua
@@ -226,7 +226,7 @@ function CraftScanRecipeConfigPanelMixin:SetupRecipeIcon()
     self.RecipeIcon.Icon:SetTexture(outputItemInfo.icon)
     self.RecipeIcon:SetScript('OnEnter', function()
         GameTooltip:SetOwner(self.RecipeIcon, 'ANCHOR_RIGHT')
-        GameTooltip:SetRecipeResultItem(self.configInfo.recipeID)
+        securecall(GameTooltip.SetRecipeResultItem, GameTooltip, self.configInfo.recipeID)
     end)
 
     self.RecipeIcon:SetScript('OnLeave', function()

--- a/Config/RecipeSchematicMenu.lua
+++ b/Config/RecipeSchematicMenu.lua
@@ -361,7 +361,7 @@ local attachButton = nil
 local function CreateMenuShownButton()
     local button = CreateFrame(
         'Button',
-        'CraftScanToggleScannerConfigButton',
+        nil,
         ProfessionsFrame.CraftingPage.SchematicForm,
         'CraftScan_ScannerConfigButtonTemplate'
     )

--- a/Customer/OrderPage.lua
+++ b/Customer/OrderPage.lua
@@ -135,7 +135,7 @@ function CraftScanCrafterOrderListElementMixin:OnLineEnter()
         local qualityIDs = C_TradeSkillUI.GetQualitiesForRecipe(response.recipeID);
         local qualityIdx = qualityIDs and #qualityIDs or 0;
         GameTooltip:SetOwner(self, "ANCHOR_RIGHT");
-        GameTooltip:SetRecipeResultItem(response.recipeID, reagents, nil, nil, qualityIDs and qualityIDs[qualityIdx]);
+        securecall(GameTooltip.SetRecipeResultItem, GameTooltip, response.recipeID, reagents, nil, nil, qualityIDs and qualityIDs[qualityIdx]);
     end
 
     -- In addition, pop up a tooltip that looks like the chat window. We copy


### PR DESCRIPTION
This PR resolves the 'tainted by CraftScan' error that causes an arithmetic crash in MoneyFrame.lua.

- Wrapped GameTooltip:SetRecipeResultItem calls in securecall to ensure update logic runs in a secure context.
- Used an anonymous frame for the toggle button in ProfessionsFrame to avoid taint propagation to secure frames.

Fixes https://github.com/stevin05/CraftScan/issues/96